### PR TITLE
refactor: rename to_csv method to write_csv for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ print(df)
 # │ null           ┆ 1970-12-04          ┆ true       ┆ 123     ┆ 123        │
 # └────────────────┴─────────────────────┴────────────┴─────────┴────────────┘
 
-df.ja.to_csv("output_sjis.csv", encoding="shift_jis")
+df.ja.write_csv("output_sjis.csv", encoding="shift_jis")
 ```
 
 ## 主な機能 (Features)
@@ -91,4 +91,4 @@ df.ja.to_csv("output_sjis.csv", encoding="shift_jis")
     *   `ja_pref.to_romaji()`: ローマ字表記（大文字）に変換。
     *   `ja_pref.to_region()`: 地方名（例: 「関東」「近畿」）に変換。
 *   **CSVエンコーディング指定出力:** DataFrameを指定したエンコーディングでCSVファイルに出力します。
-    *   `DataFrame.ja.to_csv(path, encoding="shift_jis", **kwargs)`: DataFrameをCSVファイルに書き込みます。
+    *   `DataFrame.ja.write_csv(path, encoding="shift_jis", **kwargs)`: DataFrameをCSVファイルに書き込みます。

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,7 +59,7 @@ print(df)
 # │ null           ┆ 1970-12-04          ┆ true       ┆ 123     ┆ 123        │
 # └────────────────┴─────────────────────┴────────────┴─────────┴────────────┘
 
-df.ja.to_csv("output_sjis.csv", encoding="shift_jis")
+df.ja.write_csv("output_sjis.csv", encoding="shift_jis")
 ```
 
 ## 主な機能 (Features)
@@ -87,4 +87,4 @@ df.ja.to_csv("output_sjis.csv", encoding="shift_jis")
     *   `ja_pref.to_romaji()`: 都道府県名またはコードを一般的なローマ字表記（大文字）に変換します。
     *   `ja_pref.to_region()`: 都道府県名またはコードを地方名（例: 「関東」「近畿」）に変換します。
 *   **CSVエンコーディング指定出力:** DataFrameを指定したエンコーディングでCSVファイルに出力します。
-    *   `DataFrame.ja.to_csv(path, encoding="shift_jis", **kwargs)`: DataFrameをCSVファイルに書き込みます。
+    *   `DataFrame.ja.write_csv(path, encoding="shift_jis", **kwargs)`: DataFrameをCSVファイルに書き込みます。

--- a/python/polars_japanese/common.py
+++ b/python/polars_japanese/common.py
@@ -179,7 +179,7 @@ class JapaneseDataFrame:
     def __init__(self, df: pl.DataFrame):
         self._df = df
 
-    def to_csv(
+    def write_csv(
         self,
         path: Union[str, pathlib.Path],
         encoding: str = "utf-8",
@@ -203,7 +203,7 @@ class JapaneseDataFrame:
             >>> import polars_japanese # noqa: F401
             >>> df = pl.DataFrame({"col1": ["テスト", "一"], "col2": [1, 2]})
             >>> # Shift-JISエンコーディングでCSVに書き込む
-            >>> # df.ja.to_csv("output.csv", encoding="shift_jis")
+            >>> # df.ja.write_csv("output.csv", encoding="shift_jis")
         """
         try:
             # ファイルを開く前にエンコーディングが有効か確認

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,19 +1,18 @@
 import pathlib
 
 import polars as pl
+import polars_japanese  # noqa: F401
 import pytest
 from polars.testing import assert_frame_equal
 
-import polars_japanese  # noqa: F401
 
-
-def test_to_csv_encoding_sjis(tmp_path: pathlib.Path) -> None:
+def test_write_csv_encoding_sjis(tmp_path: pathlib.Path) -> None:
     """Shift-JISエンコーディングでCSVファイルが出力されることをテストする"""
     df = pl.DataFrame({"col1": ["テスト", "データ"], "col2": [1, 2]})
     output_path = tmp_path / "test_sjis.csv"
 
-    # ja名前空間経由でto_csvを呼び出す
-    df.ja.to_csv(output_path, encoding="shift_jis")
+    # ja名前空間経由でwrite_csvを呼び出す
+    df.ja.write_csv(output_path, encoding="shift_jis")
 
     # 出力されたファイルをShift-JISで読み込み、内容を確認する
     with open(output_path, "r", encoding="shift_jis") as f:
@@ -26,13 +25,13 @@ def test_to_csv_encoding_sjis(tmp_path: pathlib.Path) -> None:
     assert_frame_equal(df, read_df)
 
 
-def test_to_csv_encoding_utf8(tmp_path: pathlib.Path) -> None:
+def test_write_csv_encoding_utf8(tmp_path: pathlib.Path) -> None:
     """UTF-8エンコーディングでCSVファイルが出力されることをテストする"""
     df = pl.DataFrame({"col1": ["テスト", "データ"], "col2": [1, 2]})
     output_path = tmp_path / "test_utf8.csv"
 
-    # ja名前空間経由でto_csvを呼び出す
-    df.ja.to_csv(output_path, encoding="utf-8")
+    # ja名前空間経由でwrite_csvを呼び出す
+    df.ja.write_csv(output_path, encoding="utf-8")
 
     # 出力されたファイルをUTF-8で読み込み、内容を確認する
     with open(output_path, "r", encoding="utf-8") as f:
@@ -45,11 +44,11 @@ def test_to_csv_encoding_utf8(tmp_path: pathlib.Path) -> None:
     assert_frame_equal(df, read_df)
 
 
-def test_to_csv_encoding_unsupported(tmp_path: pathlib.Path) -> None:
+def test_write_csv_encoding_unsupported(tmp_path: pathlib.Path) -> None:
     """サポートされていないエンコーディングを指定した場合にエラーが発生することをテストする"""
     df = pl.DataFrame({"col1": ["テスト", "データ"], "col2": [1, 2]})
     output_path = tmp_path / "test_unsupported.csv"
 
     with pytest.raises(LookupError):
-        # ja名前空間経由でto_csvを呼び出す
-        df.ja.to_csv(output_path, encoding="unsupported_encoding")
+        # ja名前空間経由でwrite_csvを呼び出す
+        df.ja.write_csv(output_path, encoding="unsupported_encoding")


### PR DESCRIPTION
polarsに合わせて、to_csvをwrite_csvに名前修正